### PR TITLE
Fix GSNSignatureMock inheritance

### DIFF
--- a/contracts/mocks/GSNRecipientSignatureMock.sol
+++ b/contracts/mocks/GSNRecipientSignatureMock.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.5.0 <0.7.0;
 import "../GSN/GSNRecipient.sol";
 import "../GSN/GSNRecipientSignature.sol";
 
-contract GSNRecipientSignatureMock is GSNRecipient, GSNRecipientSignature {
+contract GSNRecipientSignatureMock is GSNRecipientSignature {
     constructor(address trustedSigner) public GSNRecipientSignature(trustedSigner) {
         // solhint-disable-previous-line no-empty-blocks
     }
@@ -14,31 +14,11 @@ contract GSNRecipientSignatureMock is GSNRecipient, GSNRecipientSignature {
         emit MockFunctionCalled();
     }
 
-    function acceptRelayedCall(
-        address relay,
-        address from,
-        bytes calldata encodedFunction,
-        uint256 transactionFee,
-        uint256 gasPrice,
-        uint256 gasLimit,
-        uint256 nonce,
-        bytes calldata approvalData,
-        uint256 maxPossibleCharge
-    )
-        external
-        override(IRelayRecipient, GSNRecipientSignature)
-        view
-        returns (uint256, bytes memory)
-    {
-        // TODO Implement
-        return super.acceptRelayedCall(relay, from, encodedFunction, transactionFee, gasPrice, gasLimit, nonce, approvalData, maxPossibleCharge);
-    }
-
     function _preRelayedCall(
         bytes memory context
     )
         internal
-        override(GSNRecipient, GSNRecipientSignature)
+        override
         returns (bytes32)
     {
         return super._preRelayedCall(context);
@@ -51,7 +31,7 @@ contract GSNRecipientSignatureMock is GSNRecipient, GSNRecipientSignature {
         bytes32 preRetVal
     ) 
         internal
-        override(GSNRecipient, GSNRecipientSignature)
+        override
     {
         super._postRelayedCall(context, success, actualCharge, preRetVal);
     }


### PR DESCRIPTION
I think mentioning this base is superfluous and if we remove it, we don't need to override the base function at all...